### PR TITLE
Chapter 3: Add Operand Address Mode Handling

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,6 +1,38 @@
  // TODO: Implement this in another MR.
 // Addressing Modes
+pub enum AddressingMode {
 	// List of Addressing Modes in Enum listing
+
+	// Immediate
+	Immediate,
+
+	// Zero Page
+	ZeroPage,
+
+	// Zero Page X
+	ZeroPageX,
+
+	// Zero Page Y
+	ZeroPageY,
+
+	// Absolute
+	Absolute,
+
+	// Absolute X
+	AbsoluteX,
+
+	// Absolute Y
+	AbsoluteY,
+
+	// Indirect X
+	IndirectX,
+
+	// Indirect Y
+	IndirectY,
+
+	// None Addressing
+	NoneAddressing,
+}
 
 // A Table-like reference to hold information about ops codes.
 // TODO: Implement this in another MR.
@@ -141,6 +173,70 @@ impl CPU {
 	// get_operand_address determines how an address should be read.
 	// It is determined based off of the Addressing mode.
 	// TODO: Implement this in another MR.
+		// Check what mode is passed in.
+
+			// Immediate
+				// Return the current value of the pc.
+
+			// Zero Page
+				// Read the value stored on 1 address.
+				// The value of the address is the value of the pc.
+
+			// Absolute
+				// Read the value stored on 2 adjacent addresses.
+				// The value of the first address is the value of the pc. 
+
+			// Zero Page X
+				// Read 1 value stored on 1 address and add value of x to it.
+				// The value of the address is the value of the pc.
+				// These are added together. If the value overflows the available byte space, it will restart from 0.
+				
+			// Zero Page Y
+				// Read 1 value stored on 1 address and add value of y to it.
+				// The value of the address is the value of the pc.
+				// These are added together. If the value overflows the available byte space, it will restart from 0.
+
+			// Absolute X
+				// Read the value stored on 2 adjacent address and add value of x to it.
+				// The value of the first address is the value of the pc.
+				// These are added together. If the value overflows the available byte space, it will restart from 0.
+
+			// Absolute Y
+				// Read the value stored on 2 adjacent address and add value of y to it.
+				// The value of the first address is the value of the pc.
+				// These are added together. If the value overflows the available byte space, it will restart from 0.
+
+			// Indirect X
+				// Read the value stored on 1 address.
+				// The value of the address is the value of the pc.
+				
+				// Add x to the value. If the value overflows the available byte space, it will restart from 0. This will be the pointer.
+
+				// Read the low value stored on the pointer.
+
+				// Read the high value stored on the pointer.
+
+				// Put the high value on the lower end, and low value on the higher end.
+				// This is a little endian.
+				// Return this computation.
+
+
+			// Indirect Y
+				// Read the value stored on 1 address.
+				// The value of the address is the value of the pc.
+				
+				// Add y to the value. If the value overflows the available byte space, it will restart from 0. This will be the pointer.
+
+				// Read the low value stored on the pointer.
+
+				// Read the high value stored on the pointer.
+
+				// Put the high value on the lower end, and low value on the higher end.
+				// This is a little endian.
+				// Return this computation.
+
+			// None Addressing
+				// Not supported.
 
 	/*
 	 * interpret interprets the incoming instructions.
@@ -359,6 +455,28 @@ mod test {
     	assert_eq!(cpu.mem[0x5000], 0x34);
     	assert_eq!(cpu.mem[0x5001], 0x12);
 	}
+
+    // -------- Operand Addressing --------
+
+   	// Immediate
+
+	// Zero Page
+			
+	// Absolute
+			
+	// Zero Page X
+			
+	// Zero Page Y
+			
+	// Absolute X
+				
+	// Absolute Y
+				
+	// Indirect X
+
+	// Indirect Y
+			
+	// None Addressing
 
     // -------- LDA --------
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -7,7 +7,7 @@ pub enum AddressingMode {
 	Immediate,
 
 	// Zero Page
-	// ZeroPage,
+	ZeroPage,
 
 	// Zero Page X
 	// ZeroPageX,
@@ -183,8 +183,11 @@ impl CPU {
 			}
 
 			// Zero Page
+			AddressingMode::ZeroPage => {
 				// Read the value stored on 1 address.
 				// The value of the address is the value of the pc.
+				self.mem_read(self.pc) as u16
+			}
 
 			// Absolute
 				// Read the value stored on 2 adjacent addresses.
@@ -467,21 +470,32 @@ mod test {
 
     // -------- Operand Addressing --------
 
-   	// Immediate
    	#[test]
-   	fn test_get_operand_address_immediate() {
+   	fn test_get_operand_address_immediate_happypath() {
    		// Create a CPU.
    		let mut cpu = CPU::new();
 
    		// Set the pc to some value.
    		cpu.pc = 0x4343;
 
-   		// Call get_operand with Immediate mode.
-   		// Check that the expected value is returned.
+   		// Check that the expected value is returned from get_operand_address.
    		assert_eq!(cpu.get_operand_address(&AddressingMode::Immediate), 0x4343)
    	}
 
-	// Zero Page
+	#[test]
+	fn test_get_operand_address_zeropage_happypath() {
+		// Create a CPU.
+		let mut cpu = CPU::new();
+
+		// Set the pc to some value.
+		cpu.pc = 0x9043;
+
+		// Set the memory address of the pc to some value.
+		cpu.mem[cpu.pc as usize] = 0x34;
+
+   		// Check that the expected value is returned from get_operand_address.
+		assert_eq!(cpu.get_operand_address(&AddressingMode::ZeroPage), 0x34);
+	}
 			
 	// Absolute
 			

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -13,7 +13,7 @@ pub enum AddressingMode {
 	ZeroPageX,
 
 	// Zero Page Y
-	// ZeroPageY,
+	ZeroPageY,
 
 	// Absolute
 	Absolute,
@@ -208,9 +208,14 @@ impl CPU {
 			}
 				
 			// Zero Page Y
+			AddressingMode::ZeroPageY => {
 				// Read 1 value stored on 1 address and add value of y to it.
 				// The value of the address is the value of the pc.
 				// These are added together. If the value overflows the available byte space, it will restart from 0.
+				let pos = self.mem_read(self.pc);
+				let addr = pos.wrapping_add(self.y) as u16;
+				addr
+			}
 
 			// Absolute X
 				// Read the value stored on 2 adjacent address and add value of x to it.
@@ -535,7 +540,8 @@ mod test {
 		// Set the memory address of the pc to a value.
 		cpu.mem[cpu.pc as usize] = 0x01;
 
-		// Set the x value to some value.
+		// Set the x value to some value, no overflow.
+		// Can use a simple "+" as it won't overflow. 
 		cpu.x = 0x42;
 
 		// Check that the expected value is returned from get_operand_address.
@@ -563,8 +569,27 @@ mod test {
 		assert_eq!(cpu.get_operand_address(&AddressingMode::ZeroPageX), expected);
 	}
 			
-	// Zero Page Y
-			
+	#[test]
+	fn test_get_operand_address_zeropagey_happypath() {
+		// Create a CPU.
+		let mut cpu = CPU::new();
+
+		// Set the pc to some value.
+		cpu.pc = 0x4351;
+
+		// Set the memory address of the pc to a value.
+		cpu.mem[cpu.pc as usize] = 0x01;
+
+		// Set the y value to some value, no overflow.
+		cpu.y = 0x34;
+
+		// Check that the expected value is returned from get_operand_address.
+		// Can use a simple "+" as it won't overflow.
+		// 0x01 + 0x34 = 53 = 0x35
+		let expected = 0x35;
+		assert_eq!(cpu.get_operand_address(&AddressingMode::ZeroPageY), expected);
+	}
+
 	// Absolute X
 				
 	// Absolute Y

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -856,6 +856,13 @@ mod test {
 	// TODO: overflow ptr + y + 1
 
 	// None Addressing
+	#[test]
+	#[should_panic]
+	fn test_get_operand_address_none_happypath() {
+		let mut cpu = CPU::new();
+		cpu.get_operand_address(&AddressingMode::NoneAddressing);
+	}
+
 
     // -------- LDA --------
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -7,28 +7,28 @@ pub enum AddressingMode {
 	Immediate,
 
 	// Zero Page
-	ZeroPage,
+	// ZeroPage,
 
 	// Zero Page X
-	ZeroPageX,
+	// ZeroPageX,
 
 	// Zero Page Y
-	ZeroPageY,
+	// ZeroPageY,
 
 	// Absolute
-	Absolute,
+	// Absolute,
 
 	// Absolute X
-	AbsoluteX,
+	// AbsoluteX,
 
 	// Absolute Y
-	AbsoluteY,
+	// AbsoluteY,
 
 	// Indirect X
-	IndirectX,
+	// IndirectX,
 
 	// Indirect Y
-	IndirectY,
+	// IndirectY,
 
 	// None Addressing
 	NoneAddressing,
@@ -173,10 +173,14 @@ impl CPU {
 	// get_operand_address determines how an address should be read.
 	// It is determined based off of the Addressing mode.
 	// TODO: Implement this in another MR.
-		// Check what mode is passed in.
-
+	fn get_operand_address(&self, mode: &AddressingMode) -> u16 {
+ 		// Check what mode is passed in.
+ 		match mode {
 			// Immediate
+			AddressingMode::Immediate => {
 				// Return the current value of the pc.
+				self.pc
+			}
 
 			// Zero Page
 				// Read the value stored on 1 address.
@@ -236,7 +240,12 @@ impl CPU {
 				// Return this computation.
 
 			// None Addressing
+			AddressingMode::NoneAddressing => {
 				// Not supported.
+				panic!("not supported");
+			}
+		}
+	}
 
 	/*
 	 * interpret interprets the incoming instructions.
@@ -459,6 +468,18 @@ mod test {
     // -------- Operand Addressing --------
 
    	// Immediate
+   	#[test]
+   	fn test_get_operand_address_immediate() {
+   		// Create a CPU.
+   		let mut cpu = CPU::new();
+
+   		// Set the pc to some value.
+   		cpu.pc = 0x4343;
+
+   		// Call get_operand with Immediate mode.
+   		// Check that the expected value is returned.
+   		assert_eq!(cpu.get_operand_address(&AddressingMode::Immediate), 0x4343)
+   	}
 
 	// Zero Page
 			

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -508,6 +508,7 @@ mod test {
     // -------- Operand Addressing --------
     // TODO: For all the expected, use the exact value as the value of expected, rather than the formula.
     // Leave the equation used to get the number as a comment.
+    // TODO: Put the actual number on top of each address.
 
    	#[test]
    	fn test_get_operand_address_immediate_happypath() {
@@ -787,6 +788,7 @@ mod test {
 		assert_eq!(cpu.get_operand_address(&AddressingMode::IndirectX), expected);
 	}
 
+	// TODO: overflow ptr + y + 1
 
 	// Indirect Y
 	
@@ -821,23 +823,37 @@ mod test {
 	}
 
 	// overflow
+	#[test]
+	fn test_get_operand_address_indirecty_overflow() {
 		// Create a CPU.
+		let mut cpu = CPU::new();
 
 		// Set pc to some value.
+		cpu.pc = 0x12;
 
 		// Set the address of the pc to some value.
+		cpu.mem[cpu.pc as usize] = 0xdd;
 
 		// Set the y value to some value that will overflow the u16 bit space.
+		cpu.y = 0xff;
 
+		// Get the pointer.
+		// Add y to the value stored on the pc's address.
+		let ptr = cpu.mem[cpu.pc as usize].wrapping_add(cpu.y);
+		
 		// Set the address of the pc + y address value to some value.
+		cpu.mem[ptr as usize] = 0x47;
 
 		// Set the address of the pc + y + 1 address value to some value.
+		cpu.mem[ptr.wrapping_add(1) as usize] = 0x12;
 
 		// Check that the expected value is returned from get_operand_address.
 		// Cannot use a simple "+" as it will overflow the space.
+		let expected = 0x1247;
+		assert_eq!(cpu.get_operand_address(&AddressingMode::IndirectY), expected);
+	}
 
-	// overflow ptr + y + 1
-
+	// TODO: overflow ptr + y + 1
 
 	// None Addressing
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -863,7 +863,6 @@ mod test {
 		cpu.get_operand_address(&AddressingMode::NoneAddressing);
 	}
 
-
     // -------- LDA --------
 
     #[test]


### PR DESCRIPTION
## What
* Add code for operand addresses.
* Fix `mem_read_u16` to not need a `mut` `self` reference.
  * There is no need for a read to need a mutable reference. 